### PR TITLE
alan-filter-artefacts-by-tag

### DIFF
--- a/client/src/js/components/SearchBar.jsx
+++ b/client/src/js/components/SearchBar.jsx
@@ -15,7 +15,7 @@ const SearchBar = () => {
     <TextField
       id='standard-textarea'
       label='Filter'
-      placeholder='enter a title to filter artifacts'
+      placeholder='Filter by artefact name or title'
       margin='normal'
       onChange={handleChange}
       value={artifactFilter}

--- a/client/src/js/selectors/index.js
+++ b/client/src/js/selectors/index.js
@@ -27,10 +27,15 @@ export const getVisibleArtifacts = createSelector(
     switch (allFilter) {
       case true:
         return allArtifacts.filter(artifact => 
-          artifact.title
+          (artifact.title
               .toLowerCase()
               .trim()
-              .includes(artifactFilter.toLowerCase().trim()) || '^\\s*$'.match(artifactFilter)
+              .includes(artifactFilter.toLowerCase().trim()) || '^\\s*$'.match(artifactFilter))
+          ||
+          (artifact.tags
+            .toLowerCase()
+            .trim()
+            .includes(artifactFilter.toLowerCase().trim()))
         );
       default:
         // this introduced duplicates so...


### PR DESCRIPTION
Added extra filtering in index.js to allow artefacts to be filtered by tags as well as name. Updated the SearchBar to suggest both options for filtering